### PR TITLE
Remove global variable assignments

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -27,11 +27,10 @@ parser.PRODUCEALL = enums.PRODUCEALL; // TODO this should not be a global settin
 
 parser.PRODUCECOUNT = enums.PRODUCETWO;
 
-// TODO this is not the best way of doing this.
-NT = types.NT;
-T = types.T;
-Rule = types.Rule;
-Grammar = types.Grammar;
+var NT = types.NT;
+var T = types.T;
+var Rule = types.Rule;
+var Grammar = types.Grammar;
 
 
 // library code, woo


### PR DESCRIPTION
Though seemingly innocent, these prevent downstream bundles from running in strict mode.

Dependent packages should import these names as described in the README, or using destructuring:

```javascript
const {T, NT, Grammar, Rule} = gtool.types;
```